### PR TITLE
chore: add Gradle builds

### DIFF
--- a/backend/microservices/build.gradle
+++ b/backend/microservices/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.javaSaga'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
This PR adds Gradle build configuration to the project. It includes the necessary build.gradle, settings.gradle, and Gradle wrapper files to support Java-based build and dependency management. This setup will streamline project builds, improve consistency across environments, and enable integration with CI/CD pipelines.

Changes include:

Added build.gradle and settings.gradle files

Configured plugins, dependencies, and repositories

Included Gradle wrapper scripts (gradlew, gradlew.bat, gradle/wrapper/)

Why:
To standardize builds and prepare the project for scalable development and automated deployment.

If you have a specific context (e.g., migrating from Maven