### PR TITLE
feat: add order service

### DIFF
--- a/backend/microservices/orderService/Dockerfile
+++ b/backend/microservices/orderService/Dockerfile
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:17-jdk-alpine AS builder
+WORKDIR /extracted
+COPY build/libs/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=builder /extracted/dependencies/ ./
+COPY --from=builder /extracted/spring-boot-loader/ ./
+COPY --from=builder /extracted/snapshot-dependencies/ ./
+COPY --from=builder /extracted/application/ ./
+ENV SERVER_PORT=8081
+EXPOSE $SERVER_PORT
+EXPOSE 9095
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/backend/microservices/orderService/build.gradle
+++ b/backend/microservices/orderService/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.4.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.InventoryOrder'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':Utils')
+    implementation project(':proto-api')
+    //MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'net.devh:grpc-client-spring-boot-starter:2.15.0.RELEASE'
+    implementation 'net.devh:grpc-server-spring-boot-starter:2.15.0.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.grpc:grpc-netty-shaded:1.58.0'
+    implementation 'org.springframework.kafka:spring-kafka'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/Client/GrpcClient.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/Client/GrpcClient.java
@@ -1,0 +1,26 @@
+package com.InventoryOrder.Client;
+
+import com.InventoryOrder.OrderRequest;
+import com.InventoryOrder.OrderResponse;
+import com.InventoryOrder.OrderServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+public class GrpcClient {
+    public static void main(String[] args) {
+        ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 9090)
+                .usePlaintext()
+                .build();
+        OrderServiceGrpc.OrderServiceBlockingStub stub = OrderServiceGrpc.newBlockingStub(channel);
+        OrderRequest request = OrderRequest.newBuilder()
+                .setInventoryId(1)
+                .setQuantity(3)
+                .build();
+        OrderResponse response = stub.createOrder(request);
+        System.out.println("Command create : ID = " + response.getOrderId() +
+                ", Status = " + response.getStatus() +
+                ", Price total = " + response.getTotalPrice());
+
+        channel.shutdown();
+    }
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/Main.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/Main.java
@@ -1,0 +1,12 @@
+package com.InventoryOrder;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+    public static void main(String[] args) {
+        SpringApplication.run(Main.class, args);
+        System.out.println("🚀 GRPC server started on port 9090 ...");
+    }
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/Repository/OrderRepository.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/Repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.InventoryOrder.Repository;
+
+import com.InventoryOrder.model.Order;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface OrderRepository extends MongoRepository<Order, String> {
+}
+

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/broker/OrderEventHandler.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/broker/OrderEventHandler.java
@@ -1,0 +1,75 @@
+package com.InventoryOrder.broker;
+
+import com.InventoryOrder.DTOs.OrderDTO;
+import com.InventoryOrder.Events.InventoryResponseEvent;
+import com.InventoryOrder.Repository.OrderRepository;
+import com.InventoryOrder.model.Order;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class OrderEventHandler {
+    @Autowired
+    private OrderRepository repository;
+
+    @KafkaListener(topics = "Inventory-Response-topic", groupId = "OrderGroup")
+    public OrderDTO inventoryResponseConsumer(InventoryResponseEvent e) {
+        log.info("Received inventory response for order: {}", e.getOrderId());
+
+        if (e.getStatus().equals("FAILURE")) {
+            log.error("Updating Inventory Failed: {}", e.getFailureReason());
+            Order order = Order.builder()
+                    .orderId(e.getOrderId().toString())
+                    .status("FAILED")
+                    .totalAmount(0.0)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .transactionId("TXN_" + System.currentTimeMillis())
+                    .build();
+
+            Order savedOrder = repository.save(order);
+            return mapToOrderDTO(savedOrder);
+        } else {
+            log.info("Update Inventory with success for order with id: {}", e.getOrderId());
+            Optional<Order> orderOptional = repository.findById(e.getOrderId().toString());
+
+            if (orderOptional.isPresent()) {
+                Order order = orderOptional.get();
+                order.setStatus("PROCESSING");
+                order.setTotalAmount(e.getPrice());
+                order.setUpdatedAt(LocalDateTime.now());
+                Order savedOrder = repository.save(order);
+                return mapToOrderDTO(savedOrder);
+            } else {
+                log.error("Order not found for id: {}", e.getOrderId());
+                Order newOrder = Order.builder()
+                        .orderId(e.getOrderId().toString())
+                        .status("PROCESSING")
+                        .totalAmount(e.getPrice())
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .transactionId("TXN_" + System.currentTimeMillis())
+                        .build();
+                Order savedOrder = repository.save(newOrder);
+                return mapToOrderDTO(savedOrder);
+            }
+        }
+    }
+
+    private OrderDTO mapToOrderDTO(Order order) {
+        return OrderDTO.builder()
+                .orderId(Long.parseLong(order.getOrderId()))
+                .status(order.getStatus())
+                .totalAmount(order.getTotalAmount())
+                .createdAt(order.getCreatedAt())
+                .updatedAt(order.getUpdatedAt())
+                .transactionId(order.getTransactionId())
+                .build();
+    }
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/broker/OrderEventProducer.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/broker/OrderEventProducer.java
@@ -1,0 +1,21 @@
+package com.InventoryOrder.broker;
+
+import com.InventoryOrder.Events.OrderEvent;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderEventProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderEventProducer.class);
+    private final KafkaTemplate<String, OrderEvent> kafkaTemplate;
+
+    public void sendOrderEvent(OrderEvent event) {
+        log.info("Sending order event to Inventory service for order: {}", event.getOrderId());
+        kafkaTemplate.send("order-event-topic", event);
+    }
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/config/GrpcClientConfig.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/config/GrpcClientConfig.java
@@ -1,0 +1,23 @@
+package com.InventoryOrder.config;
+
+import com.InventoryOrder.OrderServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcClientConfig {
+
+    @Bean
+    public ManagedChannel managedChannel() {
+        return ManagedChannelBuilder.forAddress("localhost", 9095)
+                .usePlaintext()
+                .build();
+    }
+
+    @Bean
+    public OrderServiceGrpc.OrderServiceBlockingStub orderStub(ManagedChannel channel) {
+        return OrderServiceGrpc.newBlockingStub(channel);
+    }
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/config/WebSocketConfig.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/config/WebSocketConfig.java
@@ -1,0 +1,21 @@
+package com.InventoryOrder.config;
+
+import com.InventoryOrder.controller.WebSocketOrderHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.*;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final WebSocketOrderHandler orderHandler;
+
+    public WebSocketConfig(WebSocketOrderHandler orderHandler) {
+        this.orderHandler = orderHandler;
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(orderHandler, "/ws/orders").setAllowedOrigins("*");
+    }
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/controller/OrderRestController.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/controller/OrderRestController.java
@@ -1,0 +1,102 @@
+// package com.InventoryOrder.controller;
+
+// import com.InventoryOrder.OrderRequest;
+// import com.InventoryOrder.OrderResponse;
+// import com.InventoryOrder.OrderListResponse;
+// import com.InventoryOrder.OrderServiceGrpc;
+// import com.google.protobuf.Empty;
+// import lombok.RequiredArgsConstructor;
+// import org.springframework.web.bind.annotation.*;
+// import io.grpc.ManagedChannel;
+// import io.grpc.ManagedChannelBuilder;
+
+// import java.util.List;
+
+// @RestController
+// @RequestMapping("/api/orders")
+// @RequiredArgsConstructor
+// public class OrderRestController {
+
+//    // private final OrderServiceGrpc.OrderServiceBlockingStub orderStub;
+//     private final OrderServiceGrpc.OrderServiceBlockingStub orderStub;
+    
+//     public OrderRestController() {
+//         ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 9095)
+//                 .usePlaintext()
+//                 .build();
+//         this.orderStub = OrderServiceGrpc.newBlockingStub(channel);
+//     }
+
+//     @PostMapping
+//     public OrderDto createOrder(@RequestBody OrderRequestDto dto) {
+
+//         OrderRequest grpcRequest = OrderRequest.newBuilder()
+//                 .setInventoryId(dto.inventoryId())
+//                 .setQuantity(dto.quantity())
+//                 .build();
+
+//         OrderResponse grpcResponse = orderStub.createOrder(grpcRequest);
+
+//         return new OrderDto(grpcResponse.getOrderId(), grpcResponse.getStatus(), grpcResponse.getTotalPrice());
+//     }
+
+//     @GetMapping
+//     public List<OrderDto> getAllOrders() {
+//         OrderListResponse response = orderStub.getAllOrders(Empty.getDefaultInstance());
+
+//         return response.getOrdersList().stream()
+//                 .map(order -> new OrderDto(order.getOrderId(), order.getStatus(), order.getTotalPrice()))
+//                 .toList();
+//     }
+
+//     // DTO to receive data from the client
+//     public record OrderRequestDto(long inventoryId, int quantity) {}
+
+//     // DTO to return to the client (Jackson serializable)
+//     public record OrderDto(long orderId, String status, double totalPrice) {}
+// }
+
+package com.InventoryOrder.controller;
+
+import com.InventoryOrder.OrderRequest;
+import com.InventoryOrder.OrderResponse;
+import com.InventoryOrder.OrderListResponse;
+import com.InventoryOrder.OrderServiceGrpc;
+import com.google.protobuf.Empty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderRestController {
+
+    private final OrderServiceGrpc.OrderServiceBlockingStub orderStub;
+
+    @PostMapping
+    public OrderDto createOrder(@RequestBody OrderRequestDto dto) {
+        OrderRequest grpcRequest = OrderRequest.newBuilder()
+                .setInventoryId(dto.inventoryId())
+                .setQuantity(dto.quantity())
+                .build();
+
+        OrderResponse grpcResponse = orderStub.createOrder(grpcRequest);
+
+        return new OrderDto(grpcResponse.getOrderId(), grpcResponse.getStatus(), grpcResponse.getTotalPrice());
+    }
+
+    @GetMapping
+    public List<OrderDto> getAllOrders() {
+        OrderListResponse response = orderStub.getAllOrders(Empty.getDefaultInstance());
+
+        return response.getOrdersList().stream()
+                .map(order -> new OrderDto(order.getOrderId(), order.getStatus(), order.getTotalPrice()))
+                .toList();
+    }
+
+    public record OrderRequestDto(long inventoryId, int quantity) {}
+
+    public record OrderDto(long orderId, String status, double totalPrice) {}
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/controller/WebSocketOrderHandler.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/controller/WebSocketOrderHandler.java
@@ -1,0 +1,184 @@
+// package com.InventoryOrder.controller;
+
+// import com.InventoryOrder.OrderRequest;
+// import com.InventoryOrder.OrderResponse;
+// import com.InventoryOrder.OrderListResponse;
+// import com.InventoryOrder.OrderServiceGrpc;
+// import com.google.protobuf.Empty;
+// import com.fasterxml.jackson.databind.JsonNode;
+// import com.fasterxml.jackson.databind.ObjectMapper;
+// import lombok.extern.slf4j.Slf4j;
+// import org.springframework.stereotype.Component;
+// import org.springframework.web.socket.*;
+// import org.springframework.web.socket.handler.TextWebSocketHandler;
+// import io.grpc.ManagedChannel;
+// import io.grpc.ManagedChannelBuilder;
+
+// import java.util.List;
+
+// @Slf4j
+// @Component
+// public class WebSocketOrderHandler extends TextWebSocketHandler {
+
+//     // private final OrderServiceGrpc.OrderServiceBlockingStub orderStub;
+//     // private final ObjectMapper objectMapper = new ObjectMapper();
+//     private final OrderServiceGrpc.OrderServiceBlockingStub orderStub;
+//     private final ObjectMapper objectMapper = new ObjectMapper();
+
+
+//     public WebSocketOrderHandler() {
+//         ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 9095) // ✅ Order gRPC port
+//                 .usePlaintext()
+//                 .build();
+//         this.orderStub = OrderServiceGrpc.newBlockingStub(channel);
+//     }
+
+//     @Override
+//     public void afterConnectionEstablished(WebSocketSession session) {
+//         log.info("WebSocket connected: {}", session.getId());
+//     }
+
+//     @Override
+//     public void handleTextMessage(WebSocketSession session, TextMessage message) {
+//         try {
+//             JsonNode root = objectMapper.readTree(message.getPayload());
+//             String action = root.get("action").asText();
+
+//             switch (action) {
+//                 case "createOrder" -> handleCreateOrder(session, root);
+//                 case "getAllOrders" -> handleGetAllOrders(session);
+//                 default -> session.sendMessage(new TextMessage("{\"error\": \"Unknown action: " + action + "\"}"));
+//             }
+//         } catch (Exception e) {
+//             log.error("WebSocket error", e);
+//             try {
+//                 session.sendMessage(new TextMessage("{\"error\": \"" + e.getMessage() + "\"}"));
+//             } catch (Exception ignored) {}
+//         }
+//     }
+
+//     private void handleCreateOrder(WebSocketSession session, JsonNode root) throws Exception {
+//         OrderRequestDto dto = objectMapper.treeToValue(root.get("data"), OrderRequestDto.class);
+
+//         OrderRequest grpcRequest = OrderRequest.newBuilder()
+//                 .setInventoryId(dto.inventoryId())
+//                 .setQuantity(dto.quantity())
+//                 .build();
+
+//         OrderResponse grpcResponse = orderStub.createOrder(grpcRequest);
+
+//         OrderDto responseDto = new OrderDto(
+//                 grpcResponse.getOrderId(),
+//                 grpcResponse.getStatus(),
+//                 grpcResponse.getTotalPrice()
+//         );
+
+//         session.sendMessage(new TextMessage(objectMapper.writeValueAsString(responseDto)));
+//     }
+
+//     private void handleGetAllOrders(WebSocketSession session) throws Exception {
+//         OrderListResponse response = orderStub.getAllOrders(Empty.getDefaultInstance());
+
+//         List<OrderDto> orders = response.getOrdersList().stream()
+//                 .map(order -> new OrderDto(
+//                         order.getOrderId(),
+//                         order.getStatus(),
+//                         order.getTotalPrice()
+//                 ))
+//                 .toList();
+
+//         String json = objectMapper.writeValueAsString(orders);
+//         session.sendMessage(new TextMessage(json));
+//     }
+
+//     // Incoming WebSocket payload structure
+//     public record OrderRequestDto(long inventoryId, int quantity) {}
+
+//     // Outgoing response structure (for JSON serialization)
+//     public record OrderDto(long orderId, String status, double totalPrice) {}
+// }
+
+package com.InventoryOrder.controller;
+
+import com.InventoryOrder.OrderRequest;
+import com.InventoryOrder.OrderResponse;
+import com.InventoryOrder.OrderListResponse;
+import com.InventoryOrder.OrderServiceGrpc;
+import com.google.protobuf.Empty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.*;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketOrderHandler extends TextWebSocketHandler {
+
+    private final OrderServiceGrpc.OrderServiceBlockingStub orderStub;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        log.info("WebSocket connected: {}", session.getId());
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) {
+        try {
+            JsonNode root = objectMapper.readTree(message.getPayload());
+            String action = root.get("action").asText();
+
+            switch (action) {
+                case "createOrder" -> handleCreateOrder(session, root);
+                case "getAllOrders" -> handleGetAllOrders(session);
+                default -> session.sendMessage(new TextMessage("{\"error\": \"Unknown action: " + action + "\"}"));
+            }
+        } catch (Exception e) {
+            log.error("WebSocket error", e);
+            try {
+                session.sendMessage(new TextMessage("{\"error\": \"" + e.getMessage() + "\"}"));
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private void handleCreateOrder(WebSocketSession session, JsonNode root) throws Exception {
+        OrderRequestDto dto = objectMapper.treeToValue(root.get("data"), OrderRequestDto.class);
+
+        OrderRequest grpcRequest = OrderRequest.newBuilder()
+                .setInventoryId(dto.inventoryId())
+                .setQuantity(dto.quantity())
+                .build();
+
+        OrderResponse grpcResponse = orderStub.createOrder(grpcRequest);
+
+        OrderDto responseDto = new OrderDto(
+                grpcResponse.getOrderId(),
+                grpcResponse.getStatus(),
+                grpcResponse.getTotalPrice()
+        );
+
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(responseDto)));
+    }
+
+    private void handleGetAllOrders(WebSocketSession session) throws Exception {
+        OrderListResponse response = orderStub.getAllOrders(Empty.getDefaultInstance());
+
+        List<OrderDto> orders = response.getOrdersList().stream()
+                .map(order -> new OrderDto(
+                        order.getOrderId(),
+                        order.getStatus(),
+                        order.getTotalPrice()
+                ))
+                .toList();
+
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(orders)));
+    }
+
+    public record OrderRequestDto(long inventoryId, int quantity) {}
+    public record OrderDto(long orderId, String status, double totalPrice) {}
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/model/Order.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/model/Order.java
@@ -1,0 +1,28 @@
+package com.InventoryOrder.model;
+
+import com.InventoryOrder.DTOs.InventoryDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Order {
+    @Id
+    private String orderId;  // MongoDB uses String as the default type for ObjectId
+    private Long InventoryId;
+    private String status;
+    private InventoryDTO Inventory; // Single Inventory
+    private Double totalAmount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String transactionId;
+}

--- a/backend/microservices/orderService/src/main/java/com/InventoryOrder/server/GrpcOrderService.java
+++ b/backend/microservices/orderService/src/main/java/com/InventoryOrder/server/GrpcOrderService.java
@@ -1,0 +1,79 @@
+package com.InventoryOrder.server;
+
+import com.google.protobuf.Empty;
+import com.InventoryOrder.OrderServiceGrpc;
+import com.InventoryOrder.OrderRequest;
+import com.InventoryOrder.OrderResponse;
+import com.InventoryOrder.OrderListResponse;
+import com.InventoryOrder.Events.OrderEvent;
+import com.InventoryOrder.Repository.OrderRepository;
+import com.InventoryOrder.broker.OrderEventProducer;
+import com.InventoryOrder.model.Order;
+
+import io.grpc.stub.StreamObserver;
+import lombok.RequiredArgsConstructor;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@GrpcService
+@RequiredArgsConstructor
+public class GrpcOrderService extends OrderServiceGrpc.OrderServiceImplBase {
+
+    private final OrderRepository orderRepository;
+    private final OrderEventProducer orderEventProducer;
+
+    @Override
+    public void createOrder(OrderRequest request, StreamObserver<OrderResponse> responseObserver) {
+        long orderId = System.currentTimeMillis();
+
+        Order order = Order.builder()
+                .orderId(Long.toString(orderId))
+                .InventoryId(request.getInventoryId())
+                .status("PENDING")
+                .totalAmount(0.0)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .transactionId("TXN_" + orderId)
+                .build();
+
+        orderRepository.save(order);
+
+        OrderEvent orderEvent = new OrderEvent();
+        orderEvent.setOrderId(orderId);
+        orderEvent.setInventoryId(request.getInventoryId());
+        orderEvent.setQuantity(request.getQuantity());
+        orderEventProducer.sendOrderEvent(orderEvent);
+
+        OrderResponse response = OrderResponse.newBuilder()
+                .setOrderId(orderId)
+                .setStatus("PENDING")
+                .setTotalPrice(0.0)
+                .build();
+
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getAllOrders(Empty request, StreamObserver<OrderListResponse> responseObserver) {
+        List<Order> orders = orderRepository.findAll();
+
+        OrderListResponse.Builder responseBuilder = OrderListResponse.newBuilder();
+
+        for (Order order : orders) {
+            OrderResponse response = OrderResponse.newBuilder()
+                    .setOrderId(Long.parseLong(order.getOrderId()))
+                    .setStatus(order.getStatus())
+                    .setTotalPrice(order.getTotalAmount())
+                    .build();
+
+            responseBuilder.addOrders(response);
+        }
+
+        responseObserver.onNext(responseBuilder.build());
+        responseObserver.onCompleted();
+    }
+}
+

--- a/backend/microservices/orderService/src/main/resources/application.yml
+++ b/backend/microservices/orderService/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+server:
+  port: 8081
+spring:
+  application:
+    name: order-service
+  data:
+    mongodb:
+      host: localhost
+      port: 27017
+      database: orderservice
+      username: root
+      password: password
+      authentication-database: admin
+  kafka:
+    bootstrap-servers: kafka:29092 #${SPRING_KAFKA_BOOTSTRAP_SERVERS:kafka:29092} #localhost:9092
+    consumer:
+      group-id: OrderGroup
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: com.InventoryOrder.Events
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+grpc:
+  server:
+    port: 9095


### PR DESCRIPTION
This PR adds the Order Service responsible for handling customer orders within the system. It includes gRPC-based service methods to create and retrieve orders, enabling reliable inter-service communication and backend processing.

Changes include:

Added order.proto defining gRPC messages and OrderService

Implemented OrderServiceImpl with methods:

CreateOrder

GetOrder

ListOrders

Added request validation and logging

Connected with Inventory Service (via gRPC) to check stock

Why:
The Order Service is a foundational part of the system. It manages order lifecycle and coordinates with other services like Inventory to ensure availability and integrity.

